### PR TITLE
Update bot_tf2_mod.cpp

### DIFF
--- a/utils/RCBot2_meta/bot_tf2_mod.cpp
+++ b/utils/RCBot2_meta/bot_tf2_mod.cpp
@@ -551,12 +551,6 @@ bool CTeamFortress2Mod ::isBoss (edict_t *pEntity, float *fFactor)
 			m_pBoss = pEntity;
 			return true;
 		}
-		// TODO: to prevent shooting at ghosts? [APG]RoboCop[CL]
-		if (std::strcmp(pEntity->GetClassName(),"ghost")==0)
-		{
-			m_pBoss = pEntity;
-			return false;
-		}
 		
 	}
 	else if ( CTeamFortress2Mod::isMapType(TF_MAP_MVM) )


### PR DESCRIPTION
Removed command line for ghost.

Making Rcbots ignore ghosts entities in maps so they don't attack it and waste ammo.

such as koth_viaduct_event, pl_terror_event... etcs.